### PR TITLE
Add missing card attributes

### DIFF
--- a/pkg/card.go
+++ b/pkg/card.go
@@ -9,15 +9,21 @@ import (
 
 // A PokemonCard represents a Pokemon card and its data.
 type PokemonCard struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Supertype   string   `json:"supertype"`
-	Subtypes    []string `json:"subtypes"`
-	Level       string   `json:"level"`
-	Hp          string   `json:"hp"`
-	Types       []string `json:"types"`
-	EvolvesFrom string   `json:"evolvesFrom"`
-	Abilities   []struct {
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Supertype    string   `json:"supertype"`
+	Subtypes     []string `json:"subtypes"`
+	Level        string   `json:"level"`
+	Hp           string   `json:"hp"`
+	Types        []string `json:"types"`
+	EvolvesFrom  string   `json:"evolvesFrom"`
+	EvolvesTo    []string `json:"evolvesTo"`
+	Rules        []string `json:"rules"`
+	AncientTrait *struct {
+		Name string `json:"name"`
+		Text string `json:"text"`
+	} `json:"ancientTrait"`
+	Abilities []struct {
 		Name string `json:"name"`
 		Text string `json:"text"`
 		Type string `json:"type"`
@@ -59,6 +65,7 @@ type PokemonCard struct {
 	Number                 string `json:"number"`
 	Artist                 string `json:"artist"`
 	Rarity                 string `json:"rarity"`
+	FlavorText             string `json:"flavorText"`
 	NationalPokedexNumbers []int  `json:"nationalPokedexNumbers"`
 	Legalities             struct {
 		Unlimited string `json:"unlimited"`
@@ -91,6 +98,27 @@ type PokemonCard struct {
 			} `json:"normal,omitempty"`
 		} `json:"prices"`
 	} `json:"tcgplayer"`
+	CardMarket struct {
+		URL       string `json:"url"`
+		UpdatedAt string `json:"updatedAt"`
+		Prices    struct {
+			AverageSellPrice *float64 `json:"averageSellPrice"`
+			LowPrice         *float64 `json:"lowPrice"`
+			TrendPrice       *float64 `json:"trendPrice"`
+			GermanProLow     *float64 `json:"germanProLow"`
+			SuggestedPrice   *float64 `json:"suggestedPrice"`
+			ReverseHoloSell  *float64 `json:"reverseHoloSell"`
+			ReverseHoloLow   *float64 `json:"reverseHoloLow"`
+			ReverseHoloTrend *float64 `json:"reverseHoloTrend"`
+			LowPriceExPlus   *float64 `json:"lowPriceExPlus"`
+			Avg1             *float64 `json:"avg1"`
+			Avg7             *float64 `json:"avg7"`
+			Avg30            *float64 `json:"avg30"`
+			ReverseHoloAvg1  *float64 `json:"reverseHoloAvg1"`
+			ReverseHoloAvg7  *float64 `json:"reverseHoloAvg7"`
+			ReverseHoloAvg30 *float64 `json:"reverseHoloAvg30"`
+		} `json:"prices"`
+	} `json:"cardmarket"`
 }
 
 // GetCards allows you to search and filter for cards using given options.


### PR DESCRIPTION
A few attributes found in [the API documentation](https://docs.pokemontcg.io/api-reference/cards/card-object) were missing from this API:

* `evolvesTo`
* `rules`
* `ancientTrait`
* `flavorText`
* `cardmarket`