### PR TITLE
Add missing 1stEdition and Unlimited prices on PokemonCard model

### DIFF
--- a/pkg/card.go
+++ b/pkg/card.go
@@ -96,18 +96,30 @@ type PokemonCard struct {
 				High   float64 `json:"high"`
 				Market float64 `json:"market"`
 			} `json:"normal,omitempty"`
-      FirstEdition *struct {
-        Low    float64 `json:"low"`
+			FirstEdition *struct {
+				Low    float64 `json:"low"`
 				Mid    float64 `json:"mid"`
 				High   float64 `json:"high"`
 				Market float64 `json:"market"`
-      } `json:"1stEdition"`
-      Unlimited *struct {
-        Low    float64 `json:"low"`
+			} `json:"1stEdition"`
+			Unlimited *struct {
+				Low    float64 `json:"low"`
 				Mid    float64 `json:"mid"`
 				High   float64 `json:"high"`
 				Market float64 `json:"market"`
-      } `json:"unlimited"`
+			} `json:"unlimited"`
+			FirstEditionHolofoil *struct {
+				Low    float64 `json:"low"`
+				Mid    float64 `json:"mid"`
+				High   float64 `json:"high"`
+				Market float64 `json:"market"`
+			} `json:"1stEditionHolofoil"`
+			UnlimitedHolofoil *struct {
+				Low    float64 `json:"low"`
+				Mid    float64 `json:"mid"`
+				High   float64 `json:"high"`
+				Market float64 `json:"market"`
+			} `json:"unlimitedHolofoil"`
 		} `json:"prices"`
 	} `json:"tcgplayer"`
 	CardMarket struct {

--- a/pkg/card.go
+++ b/pkg/card.go
@@ -96,6 +96,18 @@ type PokemonCard struct {
 				High   float64 `json:"high"`
 				Market float64 `json:"market"`
 			} `json:"normal,omitempty"`
+      FirstEdition *struct {
+        Low    float64 `json:"low"`
+				Mid    float64 `json:"mid"`
+				High   float64 `json:"high"`
+				Market float64 `json:"market"`
+      } `json:"1stEdition"`
+      Unlimited *struct {
+        Low    float64 `json:"low"`
+				Mid    float64 `json:"mid"`
+				High   float64 `json:"high"`
+				Market float64 `json:"market"`
+      } `json:"unlimited"`
 		} `json:"prices"`
 	} `json:"tcgplayer"`
 	CardMarket struct {


### PR DESCRIPTION
This adds the missing `1stEdition` and `unlimited` prices on the PokemonCard.

An example of a card which returns these prices is: [base3-20](https://api.pokemontcg.io/v2/cards/base3-20)